### PR TITLE
Improve pair programming description

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,10 +51,14 @@
                 <li class="equal-height-columns"><i class="cbp_tmicon rounded-x hidden-xs"></i>
                     <div class="cbp_tmlabel equal-height-column" style="height: 148px;">
                         <h2 id="PairProgramming">Pair Programming Session</h2>
-                        <p>This session will take around two hours and will be done remotely over Google Hangout. One developer will be participating. There will be two main sections: a straighforward programming session and a discussion over a conceptual problem.</p>
+                        <p>This session will take around two hours and will be done remotely over Google Hangout. 
+				One developer will be participating. There will be two main sections: 
+				a straighforward programming session and a general discussion about your technical 
+				preferences or experiences.</p>
 
 		<p>
-                            During the pair programming exercise you'll be working together with one of the developers
+                            During the <a href="https://martinfowler.com/articles/on-pair-programming.html">pair programming</a>
+			    exercise you'll be working together with one of the developers
                             on refactoring a small set of self contained legacy code. No knowledge of
                             MediaWiki or other such specific technology is required. You will have the
                             choice between doing the exercise in PHP and in JS.


### PR DESCRIPTION
Change description of the pair programming session plan to reflect our practice.
Add a link to an article about pair programming to give people who've never done pair programming an idea of the concept.