### PR TITLE
Updated outdated links

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,8 +152,7 @@ This will allow us to get a better understanding
             <h2>Useful links</h2>
 
             <p>
-                You can <a href="https://wikimedia-deutschland.softgarden.io/en/vacancies">view our current vacancies</a>
-                or <a href="https://wikimedia.de/en/people/staff">discover who you might be working with</a>.
+                You can <a href="https://wikimedia-deutschland.softgarden.io/en/vacancies">view our current vacancies</a>.
             </p>
 
             <p>
@@ -167,7 +166,7 @@ This will allow us to get a better understanding
 
 <footer class="py-5 bg-dark">
     <div class="container">
-        <p class="m-0 text-center"><a href="https://wikimedia.de/en/imprint" class="text-white">Impressum & Datenschutz</a></p>
+        <p class="m-0 text-center"><a href="https://www.wikimedia.de/impressum/" class="text-white">Impressum</a></p>
     </div>
 </footer>
 


### PR DESCRIPTION
Adjusted linked to Impressum on wikimedia.de, and removed the link to staff members page which is no longer provided.